### PR TITLE
added an award number xpath

### DIFF
--- a/src/main/resources/checks/nsf.award.number.in.db.xml
+++ b/src/main/resources/checks/nsf.award.number.in.db.xml
@@ -62,6 +62,6 @@ if (is.null(awards)) {
 ]]></code>
 	<selector>
 		<name>awards</name>
-		<xpath>/eml/dataset/project/funding//para</xpath>
+		<xpath>/eml/dataset/project/funding//para | /eml/dataset/project/funding</xpath>
 	</selector>
 </mdq:check>

--- a/src/main/resources/checks/nsf.award.number.present.xml
+++ b/src/main/resources/checks/nsf.award.number.present.xml
@@ -32,6 +32,6 @@ if (is.null(awards)) {
 }]]></code>
 	<selector>
 		<name>awards</name>
-		<xpath>/eml/dataset/project/funding//para</xpath>
+		<xpath>/eml/dataset/project/funding//para | /eml/dataset/project/funding</xpath>
 	</selector>
 </mdq:check>


### PR DESCRIPTION
I noticed some packages were failing the award number check, for example: https://arcticdata.io/catalog/quality/urn%3Auuid%3Ab6a9d4a1-ed3e-4b6f-84cd-501ed24a7c9f.  I think it's because oftentimes the funding number is not wrapped in `<para>` tags, so hopefully adding the alternative `xpath` does the trick!